### PR TITLE
feature(orderedmap): provide support for callbacks deleting items.

### DIFF
--- a/orderedmap/slice.go
+++ b/orderedmap/slice.go
@@ -52,6 +52,21 @@ func (s *Slice[K, V]) Range(f func(key K, value V) bool) {
 	}
 }
 
+func (s *Slice[K, V]) RangeMutable(f func(key K, value V) bool) {
+	order := make([]K, len(s.order))
+	copy(order, s.order)
+	store := make(map[K]V, len(s.store))
+	for k, v := range s.store {
+		store[k] = v
+	}
+	snap := Slice[K, V]{
+		order:  order,
+		store:  store,
+		stable: s.stable,
+	}
+	snap.Range(f)
+}
+
 func (s *Slice[K, V]) Store(k K, v V) {
 	_, loaded := s.store[k]
 	if !loaded {

--- a/types.go
+++ b/types.go
@@ -11,6 +11,12 @@ type OrderedMap[K comparable, V any] interface {
 	Store(key K, value V)
 }
 
+type OrderedMapWithRangeMutable[K comparable, V any] interface {
+	OrderedMap[K, V]
+	// RangeMutable allows its callbacks to delete map entries, operating on a snapshot.
+	RangeMutable(func(key K, value V) bool)
+}
+
 // Queue is a generic queue with no concurrency guarantees.
 // Instantiate by queue.New<implementation>Queue(sizeHint).
 // The size hint MAY be used by some implementations to optimize storage.


### PR DESCRIPTION
Fixed #59 

Also fixed the fact that `orderedmap_opaque_test.go` actually contained transparent tests.