### PR TITLE
fix(#129): align GHA maintenance and stop dependabot dropping updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,12 @@ updates:
     directory: /
     schedule:
       interval: "monthly"
+    # The workflows use more actions than the default open-PR limit of 5, and
+    # unmerged PRs keep holding that quota, so the lowest-ranked updates were
+    # silently never proposed: six of the eight months to 2026-08 produced no
+    # updates at all, and setup-go was never offered 7.0.0.
+    # Grouping makes the limit unreachable; the raised limit is belt and braces.
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/check-first-week.yml
+++ b/.github/workflows/check-first-week.yml
@@ -1,0 +1,30 @@
+name: Check first week of month
+
+permissions: {}
+
+on:
+  workflow_call:
+    outputs:
+      is-first-week:
+        description: "'true' if today is in the first week of the month"
+        value: ${{ jobs.check.outputs.is-first-week }}
+
+jobs:
+  check:
+    name: Check first week of month
+    runs-on: ubuntu-latest
+    outputs:
+      is-first-week: ${{ steps.check.outputs.is-first-week }}
+    steps:
+      # Callers restrict the weekday in their own cron, so day-of-month <= 7 is
+      # what turns "every Saturday" into "the first Saturday". Kept weekday-
+      # agnostic so callers scheduled on any day can share this gate.
+      - name: Check if today is in the first week of the month
+        id: check
+        run: |
+          day=$(date +%-d)
+          if [ "$day" -le 7 ]; then
+            echo "is-first-week=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-first-week=false" >> "$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,15 +23,20 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '45 6 1-7 * 6'
+    - cron: '45 6 * * 6' # 06:45 UTC every Saturday; first-week check is in the job condition
 
 # Declare default permissions as read only.
 permissions:
   contents: read
 
 jobs:
+  check-schedule:
+    uses: ./.github/workflows/check-first-week.yml
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: check-schedule
+    if: github.event_name != 'schedule' || needs.check-schedule.outputs.is-first-week == 'true'
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources
@@ -69,28 +74,28 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
       # or others). This is typically only required for manual builds.
       # - name: Setup runtime (example)
       #   uses: actions/setup-example@v1
       - name: Set up required Go version
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: 1.24
+          go-version-file: go.mod
 
       - name: Ensure actual Go version
         run: go version
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -104,7 +109,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
       #   If the Autobuild fails above, remove it and uncomment the following three lines.
       #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
       # - run: |
@@ -129,6 +134,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
       - name: 'Checkout Repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261 # v4.8.2
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,7 +10,7 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '44 20 1-7 * 4'
+    - cron: '44 20 * * 4' # 20:44 UTC every Thursday; first-week check is in the job condition
   push:
     branches: [ "main" ]
 
@@ -18,8 +18,13 @@ on:
 permissions: read-all
 
 jobs:
+  check-schedule:
+    uses: ./.github/workflows/check-first-week.yml
+
   analysis:
     name: Scorecard analysis
+    needs: check-schedule
+    if: github.event_name != 'schedule' || needs.check-schedule.outputs.is-first-week == 'true'
     runs-on: ubuntu-latest
     permissions:
       # Needed to upload the results to code-scanning dashboard.
@@ -32,17 +37,17 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -76,6 +81,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           sarif_file: results.sarif

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,18 +1,20 @@
 name: Update
 
-env:
-  GO_VERSION: 1.24
-
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 2 1-7 * 6" # 2am UTC, monthly on the first Saturday of each month
+    - cron: "0 2 * * 6" # 2am UTC every Saturday; first-week check is in the job condition
 
 permissions:
   contents: read
 
 jobs:
+  check-schedule:
+    uses: ./.github/workflows/check-first-week.yml
+
   dep_update:
+    needs: check-schedule
+    if: github.event_name != 'schedule' || needs.check-schedule.outputs.is-first-week == 'true'
     permissions:
       contents: write  # for peter-evans/create-pull-request to create branch
       pull-requests: write  # for peter-evans/create-pull-request to create a PR
@@ -21,17 +23,18 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
-      - name: Install Go
-        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
+      # Checkout first: go-version-file reads go.mod from the working tree.
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
 
       - name: Update minor and patch-level dependencies
         run: go get -t -u ./...

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,16 +15,16 @@ jobs:
       OS: ubuntu-latest
     steps:
     - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+      uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Go
-      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
-        go-version: 1.24
+        go-version-file: go.mod
 
     - name: Test and cover
       # We don't need the benchmarks to run for long, just enough for coverage.

--- a/.idea/container.iml
+++ b/.idea/container.iml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
   <component name="Go" enabled="true" />
+  <component name="GoModuleSettings" enabled="true" />
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="inheritedJdk" />

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Go containers
 
 [![GoDoc](https://pkg.go.dev/badge/github.com/fgm/container)](https://pkg.go.dev/github.com/fgm/container)
-[![Go Report Card](https://goreportcard.com/badge/github.com/fgm/container)](https://goreportcard.com/report/github.com/fgm/container)
 [![github](https://github.com/fgm/container/actions/workflows/workflow.yml/badge.svg)](https://github.com/fgm/container/actions/workflows/workflow.yml)
 [![codecov](https://codecov.io/gh/fgm/container/branch/main/graph/badge.svg?token=8YYX1B720M)](https://codecov.io/gh/fgm/container)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/fgm/container/badge)](https://securityscorecards.dev/viewer/?uri=github.com/fgm/container)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fgm/container
 
-go 1.24.7
+go 1.26.7
 
 require github.com/google/go-cmp v0.7.0
 


### PR DESCRIPTION
Dependabot ran on the default open-pull-requests-limit of 5 against 8 actions, and unmerged PRs keep holding that quota, so lower-ranked updates were never proposed: six of the eight months to 2026-08 produced none at all. Grouping makes the limit unreachable.

In the same area:

- The three scheduled workflows used "1-7 * <weekday>" crons. Cron ORs day-of-month with day-of-week, so Update fired ten times in August rather than once. The day-of-month test moves into a shared check-first-week.yml, named for the week rather than for Saturday so scorecard's Thursday schedule can share it.
- setup-go took a hardcoded 1.24 in three places and now reads go.mod. update.yml ran setup-go before checkout, which go-version-file cannot support, so those two steps are swapped.
- go.mod moves to 1.26.7: lowest supported minor, at its latest patch.
- The six actions dependabot never reached are bumped to latest, matching the SHAs fgm/envrun already runs.
- The Go Report Card badge is dropped; the service shut down.